### PR TITLE
Ajout d’instructions d’utilisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,17 @@
+# Bépo clavier externe
+
 Application Android pour le support bépo des clavier externes. Nécessite Android 4.1 minimum.
 
 Android app(4.1+) providing an external keyboard layout for bépo, a french dvorak-like keymap.
 
+# Utilisation
+
+1. Paramètres -> Langue et saisie.
+2. Brancher le clavier externe.
+3. Cliquer sur le clavier externe qui devrait avoir été détecté.
+4. Cliquer sur « Configurer les disposition clavier ».
+5. Descendre jusqu’à « Français », ajouter Bépo et valider.
+6. Choisir la disposition Bépo.
+
+Ou voir [cette page sur bepo.fr](http://bepo.fr/wiki/BepoAndroid)
+pour des copies d’écran.


### PR DESCRIPTION
J’ai aussi fait des copies d’écran, mais en rédigeant la modif, je me suis rendu compte que des instructions étaient aussi dispo ici: http://bepo.fr/wiki/BepoAndroid
